### PR TITLE
fix: add proper ending message

### DIFF
--- a/cmd/petsd/main.go
+++ b/cmd/petsd/main.go
@@ -21,7 +21,7 @@ func main() {
 		os.Exit(-1)
 	}
 
-	log.Println("terminated")
+	log.Println("finishin application")
 }
 
 func newApplicationServer() *application.Server {


### PR DESCRIPTION
* problem: when application ends it does not print a proper message.
* solution: add a readable message to show app is finishing.